### PR TITLE
Feature: Add "Current" time option for DateAdded source

### DIFF
--- a/Jellyfin.Plugin.DateAddedAdvanced/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.DateAddedAdvanced/Configuration/PluginConfiguration.cs
@@ -29,6 +29,7 @@ namespace MediaBrowser.Providers.Plugins.NfoCreateDate.Configuration
             Created,
             Oldest,
             Newest,
+            Current,
         }
 
         /// <summary>

--- a/Jellyfin.Plugin.DateAddedAdvanced/Configuration/config.html
+++ b/Jellyfin.Plugin.DateAddedAdvanced/Configuration/config.html
@@ -50,6 +50,7 @@
                             <option value="Modified">Modified</option>
                             <option value="Newest">Newest</option>
                             <option value="Oldest">Oldest</option>
+                            <option value="Current">Current</option>
                         </select>
                     </div>
                     <div class="selectContainer">
@@ -58,6 +59,7 @@
                             <option value="Modified">Modified</option>
                             <option value="Newest">Newest</option>
                             <option value="Oldest">Oldest</option>
+                            <option value="Current">Current</option>
                         </select>
                     </div>
                     <div>

--- a/Jellyfin.Plugin.DateAddedAdvanced/DateHelper.cs
+++ b/Jellyfin.Plugin.DateAddedAdvanced/DateHelper.cs
@@ -67,6 +67,14 @@ namespace Jellyfin.Plugin.DateAddedAdvanced
 
         private DateTime GetDateCreatedFromFile(FileSystemMetadata metaData, BaseItem item)
         {
+            DateSource source = item is Video ? Plugin.Instance.Configuration.DateAddedSourceVideo : Plugin.Instance.Configuration.DateAddedSourceAudio;
+            if (source == DateSource.Current)
+            {
+                var now = DateTime.UtcNow;
+                _logger.LogInformation("DateSource: {Source} - Value: {Value}. Path: {Path}", source, now, item.Path);
+                return now;
+            }
+
             var write = _fileSystem.GetLastWriteTimeUtc(metaData);
             DateTime create = default;
 
@@ -90,7 +98,6 @@ namespace Jellyfin.Plugin.DateAddedAdvanced
             }
 
             DateTime dt = DateTime.MinValue;
-            DateSource source = item is Video ? Plugin.Instance.Configuration.DateAddedSourceVideo : Plugin.Instance.Configuration.DateAddedSourceAudio;
             switch (source)
             {
                 case DateSource.Modified:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ It can be configured which file date should be used:
 * Modification date
 * Oldest from creation and modification date
 * Newest from creation and modification date
+* Current time
 
 Reasoning is that for files that do not get changed (movies, TV show episodes), the modified date is quite stable and usually does not change on the filesystem. So, even after years the modification date might be the date the file was added to your collection.
 For files that do change (e.g. music files due to re-tagging), the modified date usually does not tell when this file was added to your collection.
@@ -108,6 +109,7 @@ There are several configuration options available. You can configure the plugin 
 | Modified | Filesystem attribute "modified" |
 | Newest | Automatically select the newer timestamp from "created" and "modified" |
 | Oldest | Automatically select the older timestamp from "created" and "modified" |
+| Current | Current time |
 
 # Building from Source
 


### PR DESCRIPTION
Added a new `Current` option to the DateAddedSource configuration. This allows the user to use the current time instead of file creation/modification times when no NFO file is present. Updated `config.html`, `PluginConfiguration.cs`, `DateHelper.cs`, and `README.md`.

---
*PR created automatically by Jules for task [10076853683523191070](https://jules.google.com/task/10076853683523191070) started by @verybadsoldier*